### PR TITLE
Added a handful of things I .gitignore on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,11 @@ ehthumbs.db
 *.exe
 *.so
 *.dll
+a.out
 
 #Other things
 *.tmp
 *.log
 *.dmp
+*.swp
+core


### PR DESCRIPTION
`a.out` is the default compiliation target name. `*.swp` matches `.*.swp`, which Vim uses for lock files. `core` is a dump.